### PR TITLE
[security-fix] stop to use JeIlyfish and move to Jellyfish

### DIFF
--- a/OSMPythonToolsHandler.py
+++ b/OSMPythonToolsHandler.py
@@ -4,7 +4,7 @@ from OSMPythonTools.api import Api
 api = Api()
 import DBScript as DB
 import Logger as Log
-import jeIlyfish
+import jellyfish
 
 OSMNodesCache={}
 
@@ -46,7 +46,7 @@ def GetOSMNode(nodeID):
 
 
 def GetPhoneticCode(street):
-    code = jeIlyfish.metaphone(street)
+    code = jellyfish.metaphone(street)
     code.rsplit(' ', 1)[0]
     return code
 


### PR DESCRIPTION
JeIlyfish is a fake package who was designed to stole
files like ssk keys, pgp keys etc...

This patch stop to use it and move to the real Jellyfish library.

https://github.com/dateutil/dateutil/issues/984
https://www.zdnet.com/article/two-malicious-python-libraries-removed-from-pypi/